### PR TITLE
Change output method to reflect on the latest changes

### DIFF
--- a/scripts/init_app_release.sh
+++ b/scripts/init_app_release.sh
@@ -34,7 +34,7 @@ set_var() {
     export "${KEY}=${VAL}"
     # shellcheck disable=SC2086
     echo "${KEY}=${VAL}" >> $GITHUB_ENV
-    echo "::set-output name=${KEY}::${VAL}"
+    echo "${KEY}=${VAL}" >> $GITHUB_OUTPUT
     echo ">>> New variable exported [ ${KEY} = ${VAL} ]"
 }
 

--- a/scripts/repo_data.sh
+++ b/scripts/repo_data.sh
@@ -12,7 +12,7 @@ set_var() {
     export "${KEY}=${VAL}"
     # shellcheck disable=SC2086
     echo "${KEY}=${VAL}" >> $GITHUB_ENV
-    echo "::set-output name=${KEY}::${VAL}"
+    echo "${KEY}=${VAL}" >> $GITHUB_OUTPUT
 }
 
 resolve_app_version() {


### PR DESCRIPTION
update: scripts/init_app_release.sh
update: scripts/repo_data.sh
info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/