### PR TITLE
Feature/support for additional branches v2

### DIFF
--- a/actions/repo-data/README.md
+++ b/actions/repo-data/README.md
@@ -18,12 +18,6 @@ The `container_dir` option is used for monorepos. For example:
 
 Each app has its own container registry, enabling monorepo support.
 
-inputs:
-  container_dir:
-    description: "Container config directory"
-    required: false
-    default: "infra/"
-
 Example output:
 
 Repository name: reponame

--- a/actions/repo-data/README.md
+++ b/actions/repo-data/README.md
@@ -11,6 +11,19 @@ This workflow is generating 8 oputputs:
 - branch_ref
 - head_branch_ref
 
+The `container_dir` option is used for monorepos. For example:
+
+    container_dir_1/app.conf
+    container_dir_2/app.conf
+
+Each app has its own container registry, enabling monorepo support.
+
+inputs:
+  container_dir:
+    description: "Container config directory"
+    required: false
+    default: "infra/"
+
 Example output:
 
 Repository name: reponame

--- a/actions/repo-data/action.yml
+++ b/actions/repo-data/action.yml
@@ -1,6 +1,12 @@
 name: 'Repository data'
 description: 'Fetch repository and organization name'
 
+inputs:
+  container_dir:
+    description: "Container config directory"
+    required: false
+    default: "infra/"
+
 outputs:
   repo_name:
     description: "Repository name"
@@ -35,4 +41,4 @@ runs:
   steps:
     - id: repo_data
       shell: bash
-      run: ${{ github.action_path }}/../../scripts/repo_data.sh
+      run: ${{ github.action_path }}/../../scripts/repo_data.sh "${{ inputs.container_dir }}"

--- a/actions/repo-data/action.yml
+++ b/actions/repo-data/action.yml
@@ -23,9 +23,9 @@ outputs:
   app_release_type:
     description: "Application release type"
     value: ${{ steps.repo_data.outputs.APP_RELEASE_TYPE }}
-  docker_repo:
+  container_repo:
     description: "Docker repository"
-    value: ${{ steps.repo_data.outputs.DOCKER_REPO }}
+    value: ${{ steps.repo_data.outputs.CONTAINER_REPO }}
   branch_ref:
     description: "Branch reference"
     value: ${{ steps.repo_data.outputs.GITHUB_REF }}

--- a/scripts/repo_data.sh
+++ b/scripts/repo_data.sh
@@ -28,7 +28,7 @@ resolve_app_version() {
             set_var APP_VERSION "${GITHUB_HEAD_REF##release/}-rc.${GITHUB_RUN_NUMBER}"
         fi
     else
-      if [[ -z "${GITHUB_REF##*main}" ]] || [[ -z "${GITHUB_REF##*master}" ]] || [[ -z "${GITHUB_REF##*dev*}" ]]; then
+      if [[ -z "${GITHUB_REF##*main}" ]] || [[ -z "${GITHUB_REF##*master}" ]]; then
         set_var APP_RELEASE_TYPE "Alpha (Debug)"
         set_var APP_VERSION "alpha-${GITHUB_SHA::7}"
       fi
@@ -81,8 +81,9 @@ END
 }
 
 # app.conf should have specific key-value pair for example:
-# CONTAINER_REPO=hub.docker.com
-APP_CONFIG_FILE="${GITHUB_WORKSPACE}/infra/app.conf"
+# CONTAINER_REPO=hub.docker.
+CONTAINER_DIR="${2:-infra/}"
+APP_CONFIG_FILE="${GITHUB_WORKSPACE}/${CONTAINER_DIR}app.conf"
 if [[ -f "${APP_CONFIG_FILE}" ]]; then
     echo "Application Config detected! Loading parameters..."
     # shellcheck source=${GITHUB_WORKSPACE}/infra/app.conf

--- a/scripts/repo_data.sh
+++ b/scripts/repo_data.sh
@@ -82,7 +82,7 @@ END
 
 # app.conf should have specific key-value pair for example:
 # CONTAINER_REPO=hub.docker.
-CONTAINER_DIR="${2:-infra/}"
+CONTAINER_DIR="${1:-infra/}"
 APP_CONFIG_FILE="${GITHUB_WORKSPACE}/${CONTAINER_DIR}app.conf"
 if [[ -f "${APP_CONFIG_FILE}" ]]; then
     echo "Application Config detected! Loading parameters..."

--- a/scripts/repo_data.sh
+++ b/scripts/repo_data.sh
@@ -28,7 +28,7 @@ resolve_app_version() {
             set_var APP_VERSION "${GITHUB_HEAD_REF##release/}-rc.${GITHUB_RUN_NUMBER}"
         fi
     else
-      if [[ -z "${GITHUB_REF##*main}" ]] || [[ -z "${GITHUB_REF##*master}" ]]; then
+      if [[ -z "${GITHUB_REF##*main}" ]] || [[ -z "${GITHUB_REF##*master}" ]] || [[ -z "${GITHUB_REF##*dev*}" ]]; then
         set_var APP_RELEASE_TYPE "Alpha (Debug)"
         set_var APP_VERSION "alpha-${GITHUB_SHA::7}"
       fi
@@ -81,7 +81,7 @@ END
 }
 
 # app.conf should have specific key-value pair for example:
-# CONTAINER_REPO=hub.docker.
+# CONTAINER_REPO=hub.docker.com
 CONTAINER_DIR="${1:-infra/}"
 APP_CONFIG_FILE="${GITHUB_WORKSPACE}/${CONTAINER_DIR}app.conf"
 if [[ -f "${APP_CONFIG_FILE}" ]]; then


### PR DESCRIPTION
Adding container_dir option.

The `container_dir` option is used for monorepos. For example:

    container_dir_1/app.conf
    container_dir_2/app.conf

Each app has its own container registry, enabling monorepo support.

inputs:
  container_dir:
    description: "Container config directory"
    required: false
    default: "infra/"
